### PR TITLE
create WindowManager, create markdown viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Foxterm
 
-A full-stack website featuring custom [xterm.js](https://xtermjs.org/)-based terminals for the user to interact with.
+A full-stack website featuring multiple custom windows, such as [xterm.js](https://xtermjs.org/)-based terminals or markdown views, for the user to interact with.
 
 ## Quick start
 
@@ -35,10 +35,9 @@ uv run __init__.py
  - `cd`
  - `ls`
  - `pwd`
+ - `open` – Open a file in a markdown window
 
  - `fox` – Display an ASCII version of the FluentUI fox emoji
 
  - `github` – Display a hyperlink to [my] GitHub page
  - `twitter` – Display a hyperlink to [my] Twitter page
- - `open` – Open one of my social pages in a new tab\
- Available arguments: `github`, `git`, `gh`, `twitter`, `twt`, `x`.

--- a/blueprints/index/static/css/index.css
+++ b/blueprints/index/static/css/index.css
@@ -25,7 +25,7 @@ body {
     padding: 18px;
 }
 
-.terminal.ui-draggable {
+.window.ui-draggable {
     display: flex;
     flex-flow: column;
 }
@@ -34,13 +34,13 @@ body {
     filter: opacity(0);
 }
 
-.terminal .body {
+.window .body {
     border-left: var(--border);
     border-right: var(--border);
     border-bottom: var(--border);
 }
 
-.terminal .body, .xterm-screen, .xterm-viewport {
+.window .body, .xterm-screen, .xterm-viewport {
     flex: 1 1 auto;
 }
 

--- a/blueprints/index/static/css/index.css
+++ b/blueprints/index/static/css/index.css
@@ -28,6 +28,7 @@ body {
 .window.ui-draggable {
     display: flex;
     flex-flow: column;
+    animation: 0.3s ease-out window-open;
 }
 
 .ui-resizable-handle {
@@ -38,6 +39,13 @@ body {
     border-left: var(--border);
     border-right: var(--border);
     border-bottom: var(--border);
+    background-color: #2e2e2e;
+}
+
+.window .body:not(:has(.xterm)) {
+    padding: 8px;
+    overflow-y: auto;
+    overflow-x: hidden;
 }
 
 .window .body, .xterm-screen, .xterm-viewport {
@@ -66,13 +74,12 @@ body {
 .titlebar {
     width: 100%;
     height: 32px;
+    min-height: 32px;
     background-color: #221f24;
     border-radius: 4px 4px 0 0;
     display: grid;
     grid-template-columns: 1fr 32px;
     grid-template-rows: 1fr;
-    /* justify-content: right;
-    flex: 0 0 32px; */
     border-top: var(--border);
     border-left: var(--border);
     border-right: var(--border);
@@ -106,4 +113,18 @@ p {
 }
 .titlebar > button.close:active {
     background-color: #bc351f;   
+}
+
+@keyframes window-open {
+  0% {
+    transform: scale(0.9);
+    filter: opacity(0);
+  }
+  50% {
+    filter: opacity(1);
+  }
+  100% {
+    transform: scale(1);
+    filter: opacity(1);
+  }
 }

--- a/blueprints/index/static/js/commands.js
+++ b/blueprints/index/static/js/commands.js
@@ -9,10 +9,10 @@ function generateUsage(command) {
     throw new Error("generateUsage command argument must be based on Command!");
   }
 
-  let flags = command.flags.map((e) => {
+  let flags = Object.values(command.flags).map((e) => {
     return `[${e.flags.join("|")}]`;
   });
-  let kwparams = command.kwparams.map((e) => {
+  let kwparams = Object.values(command.kwparams).map((e) => {
     return `${e.required ? "" : "[" }${e.kwparams.join("|")} ${e.argName}${e.required ? "" : "]" }`;
   });
   let positional = Object.values(command.strings).map((e, i) => {
@@ -73,15 +73,15 @@ export class HelpCommand extends Command {
   }
   exec() {
     var [term, params] = [this.term, this.params];
-    if (!params.command) {
+    if (!params.strings.command) {
       this.write(`Available commands: ${commands.map((e) => {return e.name}).join(", ")}`);
       return
     }
     let command = null;
-    if (Object.keys(term.commands).includes(params.command)) {
-      command = term.commands[params.command];
-    } else if (Object.keys(term.aliases).includes(params.command)) {
-      command = term.commands[term.aliases[params.command]];
+    if (Object.keys(term.commands).includes(params.strings.command)) {
+      command = term.commands[params.strings.command];
+    } else if (Object.keys(term.aliases).includes(params.strings.command)) {
+      command = term.commands[term.aliases[params.strings.command]];
     }
     if (command == null) {
       this.write(`help: expected 1 argument\r\nTry 'help help' for more information.`);

--- a/blueprints/index/static/js/commands.js
+++ b/blueprints/index/static/js/commands.js
@@ -15,8 +15,8 @@ function generateUsage(command) {
   let kwparams = command.kwparams.map((e) => {
     return `${e.required ? "" : "[" }${e.kwparams.join("|")} ${e.argName}${e.required ? "" : "]" }`;
   });
-  let positional = command.strings.map((e) => {
-    return `${e.required ? "" : "[" }${e.name}${e.nargs !== 0 && e.nargs !== 1 ? "..." : ""}${e.required ? "" : "]" }`;
+  let positional = Object.values(command.strings).map((e, i) => {
+    return `${e.required ? "" : "[" }${Object.keys(command.strings)[i]}${e.nargs !== 0 && e.nargs !== 1 ? "..." : ""}${e.required ? "" : "]" }`;
   });
   return [command.name, kwparams.join(" "), flags.join(" "), positional.join(" ")].filter(e => e).join(" ");
 }
@@ -88,7 +88,7 @@ export class HelpCommand extends Command {
       return
     }
     if (command.description.length == 0 && command.help.length == 0) {
-      this.write(`-foxterm: help: no topics match '${params.command}'.`);
+      this.write(`-foxterm: help: no topics match '${params.strings.command}'.`);
       return
     }
     this.write(`${command.name}: ${generateUsage(command)}${command.description.length > 0 ? '\r\n\t' + command.description : ''}${command.help.length > 0 ? '\r\n\r\n' + command.help : ''}`);

--- a/blueprints/index/static/js/index.js
+++ b/blueprints/index/static/js/index.js
@@ -3,7 +3,9 @@
 // taggie pyle, 2025
 // https://github.com/tailhaver
 
+import MarkdownDisplay from "./markdown.js";
 import FTerminal from "./terminal.js"
+import WindowManager from "./windowManager.js"
 
 // $.ajaxSetup({
 //     async: false

--- a/blueprints/index/static/js/index.js
+++ b/blueprints/index/static/js/index.js
@@ -43,23 +43,24 @@ if (width >= 1280) {
     ];
 }
 
-const t1 = new FTerminal(positions[0], sizes[0]);
-const t2 = new FTerminal(positions[1], sizes[1]);
-const t3 = new FTerminal(positions[2], sizes[2]);
 
-t1.sendCommand("fox", false);
-t2.sendCommand("cat aside.txt", true, false); // i miss my kwargs
-t2.sendCommand("cat about.txt");
+WindowManager.t1 = new FTerminal(positions[0], sizes[0]);
+WindowManager.t2 = new FTerminal(positions[1], sizes[1]);
+WindowManager.t3 = new FTerminal(positions[2], sizes[2]);
+
+WindowManager.t1.sendCommand("fox", false);
+WindowManager.t2.sendCommand("cat aside.txt", true, false); // i miss my kwargs
+WindowManager.t2.sendCommand("cat about.txt");
 // hacky fix to display text
 setTimeout(() => {
-    t3.reset();
-    t3.write(`foxterm 0.3.0\r\npowered by ]8;;https://xtermjs.org/\\xterm.js]8;;\r\n\r\n${t3.homeText}`);
-    t3.sendCommand("help");
+    WindowManager.t3.reset();
+    WindowManager.t3.write(`foxterm 0.4.0\r\npowered by ]8;;https://xtermjs.org/\\xterm.js]8;;\r\n\r\n${WindowManager.t3.homeText}`);
+    WindowManager.t3.sendCommand("help");
 }, 0)
 
 $(window).on("resize", (e) => {
     if (e.target !== window) { return }
-    [t1, t2, t3].forEach((e) => {
+    WindowManager.forEach((e) => {
         e.window.lockToWindow();
     })
 })

--- a/blueprints/index/static/js/markdown.js
+++ b/blueprints/index/static/js/markdown.js
@@ -1,0 +1,19 @@
+import Window from "./window.js"
+
+var converter = new showdown.Converter()
+
+export default class MarkdownDisplay {
+  constructor(pos = [24, 24], size = [738, 457]) {
+    this.window = new Window(pos, size);
+    this.window.setTitle("markdown");
+    $(this.window.self).resizable({
+      handles: "all",
+      containment: "parent"
+    });
+    this.setText("...");
+  }
+  setText(text) {
+    this.text = text;
+    $(this.window.body).html(converter.makeHtml(this.text));
+  }
+}

--- a/blueprints/index/static/js/markdown.js
+++ b/blueprints/index/static/js/markdown.js
@@ -14,6 +14,8 @@ export default class MarkdownDisplay {
   }
   setText(text) {
     this.text = text;
+    const osc8ToMD = new RegExp(/]8;;(.+?)\\(.+?)]8;;\\/g);
+    this.text = this.text.replace(osc8ToMD, "[$2]($1)");
     $(this.window.body).html(converter.makeHtml(this.text));
   }
 }

--- a/blueprints/index/static/js/terminal.js
+++ b/blueprints/index/static/js/terminal.js
@@ -328,18 +328,18 @@ $(() => {
   var highestIndex = 5;
   $("body").on("click tap", ".close", (e) => {
     $(e.target).parent().parent().remove();
-    if ($(".terminal.ui-draggable").length == 0) {
+    if ($(".window.ui-draggable").length == 0) {
       setTimeout(() => {new FTerminal();}, 500);
     }
   })
-  $("body").on("mousedown", ".terminal.ui-draggable", (e) => {
-    const $this = $(e.target).closest('.terminal.ui-draggable');
+  $("body").on("mousedown", ".window.ui-draggable", (e) => {
+    const $this = $(e.target).closest('.window.ui-draggable');
     if ($this.css("z-index") == highestIndex + 1) {
       return
     }
     $(".focused").removeClass("focused");
     $this.addClass("focused");
-    $('.terminal[style*=z-index]').each((i, element) => {
+    $('.window[style*=z-index]').each((i, element) => {
       const index = $(element).css("z-index") - 1;
       if (index > highestIndex) {
         highestIndex = index;

--- a/blueprints/index/static/js/terminal.js
+++ b/blueprints/index/static/js/terminal.js
@@ -51,7 +51,7 @@ export default class FTerminal {
     });
 
     this.window = new Window(pos, size);
-    this.window.updateTitle("foxterm");
+    this.window.setTitle("foxterm");
     // have to manually set resizing here because if i try to pass `this` into
     // the Window obj it throws a fit. oops.
     this.window.handleWindowResize(pos, size);
@@ -323,33 +323,3 @@ export default class FTerminal {
     this.homeText = `[1;92m${this.user}@taggie-server[1;0m:[1;94m${this.dir}[0m$ `;
   }
 }
-
-$(() => {
-  var highestIndex = 5;
-  $("body").on("click tap", ".close", (e) => {
-    $(e.target).parent().parent().remove();
-    if ($(".window.ui-draggable").length == 0) {
-      setTimeout(() => {new FTerminal();}, 500);
-    }
-  })
-  $("body").on("mousedown", ".window.ui-draggable", (e) => {
-    const $this = $(e.target).closest('.window.ui-draggable');
-    if ($this.css("z-index") == highestIndex + 1) {
-      return
-    }
-    $(".focused").removeClass("focused");
-    $this.addClass("focused");
-    $('.window[style*=z-index]').each((i, element) => {
-      const index = $(element).css("z-index") - 1;
-      if (index > highestIndex) {
-        highestIndex = index;
-      }
-      if (index === 0) {
-        $(element).css("z-index", "auto");
-      } else {
-        $(element).css("z-index", index);
-      }
-    })
-    $this.css("z-index", highestIndex + 1);
-  })
-})

--- a/blueprints/index/static/js/window.js
+++ b/blueprints/index/static/js/window.js
@@ -1,6 +1,7 @@
 export default class Window {
   constructor(pos = [24, 24], size = [738, 457], resizeCallback = () => {return}) {
-    this.title = "abc"
+    this.title = "";
+    this.id = null;
     this.self = $("<div>", {"class": "window"})
       .append(
         $("<div>", {"class": "titlebar"})
@@ -41,7 +42,10 @@ export default class Window {
       this.self.css("top", windowHeight - 54);
     }
   }
-  updateTitle(title) {
+  setTitle(title) {
     this.self.find(".title").text(title);
+  }
+  setId(id) {
+    this.self.attr("window-id", id);
   }
 }

--- a/blueprints/index/static/js/window.js
+++ b/blueprints/index/static/js/window.js
@@ -1,7 +1,7 @@
 export default class Window {
   constructor(pos = [24, 24], size = [738, 457], resizeCallback = () => {return}) {
     this.title = "abc"
-    this.self = $("<div>", {"class": "terminal"})
+    this.self = $("<div>", {"class": "window"})
       .append(
         $("<div>", {"class": "titlebar"})
           .append($("<p>", {"class": "title"}))

--- a/blueprints/index/static/js/windowManager.js
+++ b/blueprints/index/static/js/windowManager.js
@@ -1,0 +1,62 @@
+import FTerminal from "./terminal.js"
+
+class _WindowManager {
+  static _windows = {};
+  static forEach(fn) {
+    Object.values(_WindowManager._windows).forEach(fn);
+  }
+}
+
+const proxyHandler = {
+  get(target, prop, receiver) {
+    if (prop in target) { return target[prop] }
+    if (prop in target._windows) { return target._windows[prop] }
+  },
+  set(target, prop, value, recv) {
+    target._windows[prop] = value;
+    target._windows[prop].window.setId(prop);
+    return true;
+  },
+  deleteProperty(target, prop) {
+    if (prop in target._windows) { 
+      $(target._windows[prop].window.self).remove();
+      delete target._windows[prop];
+      return true;
+    }
+    if (prop in target) { delete target[prop]; return true }
+  }
+};
+
+let WindowManager = new Proxy(_WindowManager, proxyHandler);
+
+$(() => {
+  var highestIndex = 5;
+  $("body").on("click tap", ".close", (e) => {
+    delete WindowManager[$(e.target).closest('.window.ui-draggable').attr("window-id")];
+    if ($(".window.ui-draggable:has(.xterm)").length == 0) {
+      setTimeout(() => {WindowManager.t1 = new FTerminal();}, 500);
+    }
+  })
+  $("body").on("mousedown", ".window.ui-draggable", (e) => {
+    const $this = $(e.target).closest('.window.ui-draggable');
+    if ($this.css("z-index") == highestIndex + 1) {
+      return
+    }
+    $(".focused").removeClass("focused");
+    $this.addClass("focused");
+    $('.window[style*=z-index]').each((i, element) => {
+      const index = $(element).css("z-index") - 1;
+      if (index > highestIndex) {
+        highestIndex = index;
+      }
+      if (index === 0) {
+        $(element).css("z-index", "auto");
+      } else {
+        $(element).css("z-index", index);
+      }
+    })
+    $this.css("z-index", highestIndex + 1);
+  })
+})
+
+export default new Proxy(_WindowManager, proxyHandler)

--- a/blueprints/index/templates/index.jinja
+++ b/blueprints/index/templates/index.jinja
@@ -19,6 +19,7 @@
     <script src="https://unpkg.com/jquery@3.7.1/dist/jquery.min.js"></script>
     <script src="https://unpkg.com/jquery-ui@1.14.1/dist/jquery-ui.min.js"></script> 
     <script src="https://unpkg.com/xterm@5.3.0"></script>
+    <script src="https://unpkg.com/showdown/dist/showdown.min.js"></script>
 
     <script src="{{ static('index', filename='js/terminal.js') }}" defer type="module"></script>
     <script src="{{ static('index', filename='js/index.js') }}" defer type="module"></script>

--- a/blueprints/term/__init__.py
+++ b/blueprints/term/__init__.py
@@ -11,6 +11,10 @@ blueprint = Blueprint(
 )
 logger = None
 
+links = {
+    "readme.md": "README.md"
+}
+
 @blueprint.route('/ls', methods=['GET'])
 async def ls():
     cwd = request.args.get("cwd")
@@ -31,9 +35,9 @@ async def ls():
     if not os.path.exists(searchpath):
         return "", 404
     logger.info(os.path.abspath(searchpath))
-    files = os.listdir(searchpath)
-    return {k: {"isDir": os.path.isdir(f"{searchpath}/{k}")} for k in files}    
-
+    files = [*os.listdir(searchpath), *links.keys()]
+    return {k: {"isDir": os.path.isdir(f"{searchpath}/{k}")} for k in files}
+           
 @blueprint.route('/cat', methods=['GET'])
 async def cat():
     cwd = request.args.get("cwd")
@@ -44,7 +48,10 @@ async def cat():
         return "", 403
     home = "static/filesystem"
     cwd = cwd.replace("~", "").rstrip("/")
-    filepath = f"{home}/{cwd + '/' if cwd else ''}{path}"
+    if path.lower() in links.keys():
+        filepath = links[path.lower()]
+    else:
+        filepath = f"{home}/{cwd + '/' if cwd else ''}{path}"
     if not os.path.exists(filepath):
         return "", 404
     with open(filepath, "r", encoding="utf-8") as fp:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "foxes-new"
-version = "0.3.0"
+version = "0.4.0"
 description = "taggie waggie's website"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/static/filesystem/about.txt
+++ b/static/filesystem/about.txt
@@ -1,4 +1,4 @@
-foxterm 0.3.0
+foxterm 0.4.0
 powered by ]8;;https://xtermjs.org/\xterm.js]8;;\
 
 made with <3 by taggie, 2025

--- a/uv.lock
+++ b/uv.lock
@@ -60,7 +60,7 @@ wheels = [
 
 [[package]]
 name = "foxes-new"
-version = "0.2.1"
+version = "0.4.0"
 source = { virtual = "." }
 dependencies = [
     { name = "quart" },


### PR DESCRIPTION
many many new things!! most importantly, a markdown window! all available files (including README.md via a symlink) can be opened in a markdown viewer powered by [showdown](https://github.com/showdownjs/showdown) via `open [file]`. 
a static WindowManager class has also been created, allowing for all windows to be accessed from multiple files and properly deleted. yay!

other changes include:
- moving .terminal to .window for better readability
- fixing `help [cmd]` to actually show the command
- fixing `generateUsage` by updating the flags used from the old version
- automatic conversion of OSC 8 links to markdown links so there isnt that Stupid Ugly Mess
- added an animation for opening windows so they dont just _pop_ in